### PR TITLE
fix(AdBegin): use pubsub to trigger handleEvent

### DIFF
--- a/src/main/java/sharierhea/events/AdBegin.java
+++ b/src/main/java/sharierhea/events/AdBegin.java
@@ -2,30 +2,33 @@ package sharierhea.events;
 
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.TwitchClient;
-import com.github.twitch4j.eventsub.events.ChannelAdBreakBeginEvent;
+import com.github.twitch4j.pubsub.domain.VideoPlaybackData;
+import com.github.twitch4j.pubsub.events.VideoPlaybackEvent;
 import sharierhea.SocketHandler;
 
 import java.util.Timer;
 import java.util.TimerTask;
 
-// Todo: see why event is never registered, could be a eventsub issue from Twitch4J?
-
-public class AdBegin extends EventListener<ChannelAdBreakBeginEvent> {
-    private SocketHandler socket;
+public class AdBegin extends EventListener<VideoPlaybackEvent> {
+    private final SocketHandler socket;
 
     public AdBegin(SimpleEventHandler eventHandler, TwitchClient client, SocketHandler socket) {
-        super(eventHandler, client, ChannelAdBreakBeginEvent.class);
+        super(eventHandler, client, VideoPlaybackEvent.class);
         this.socket = socket;
+        client.getPubSub().listenForVideoPlaybackEvents(null, "170582504");
     }
 
     @Override
-    protected void handleEvent(ChannelAdBreakBeginEvent event) {
+    protected void handleEvent(VideoPlaybackEvent event) {
+        if (event.getData().getType() != VideoPlaybackData.Type.COMMERCIAL)
+            return;
+
         sendMessage("/me An ad is starting! Code/Art/Game will be paused!");
         String currentScene = socket.getCurrentScene();
         logger.debug("currentScene: " + currentScene);
         socket.changeScene("ads");
 
-        int seconds = event.getLengthSeconds();
+        int seconds = event.getData().getLength();
         logger.debug("Seconds: " + seconds);
         Timer timer = new Timer();
         TimerTask task = new TimerTask() {


### PR DESCRIPTION
alternatively, you can use eventsub if you have a broadcaster token with the `channel:read:ads` scope (moderator token is not sufficient)

for eventsub, you were just missing
```java
client.getEventSocket().register(
    broadcasterToken,
    SubscriptionTypes.CHANNEL_AD_BREAK_BEGIN.prepareSubscription(
        builder -> builder.broadcasterUserId("170582504").build(),
        null
    )
);
```